### PR TITLE
Replaced ValueError with ZeroDivisionError

### DIFF
--- a/Fraction.py
+++ b/Fraction.py
@@ -32,7 +32,7 @@ class Fraction(object):
         if b == 0:
             return abs(a)
         else:
-            Fraction.gcd(b, a % b)
+            return Fraction.gcd(b, a % b)
 
 
     def get_numerator(self):

--- a/Fraction.py
+++ b/Fraction.py
@@ -13,9 +13,8 @@ class Fraction(object):
         if not isinstance(numerator, int) or not isinstance(denominator, int):
             raise TypeError("Both numerator and denominator must be integers")
 
-        # Check for zero denominator
         if denominator == 0:
-            raise ValueError("Denominator cannot be zero")
+            raise ZeroDivisionError
             
         # Handle negative signs
         if denominator < 0:
@@ -24,8 +23,8 @@ class Fraction(object):
             
         # Reduce the fraction using GCD
         gcd = self.gcd(abs(numerator), abs(denominator))
-        self._numerator = numerator // gcd
-        self._denominator = denominator // gcd
+        self.numerator = numerator // gcd
+        self.denominator = denominator // gcd
     def gcd(a, b):
         #TODO
         pass
@@ -41,3 +40,8 @@ class Fraction(object):
     def get_fraction(self):
         #TODO
         pass
+
+class ZeroDivisionError(Exception):
+    def __init__(self, message="Denominator cannot be zero"):
+        self.message = message
+        super.__init__(self.message)

--- a/Fraction.py
+++ b/Fraction.py
@@ -22,12 +22,18 @@ class Fraction(object):
             denominator = -denominator
             
         # Reduce the fraction using GCD
-        gcd = self.gcd(abs(numerator), abs(denominator))
-        self.numerator = numerator // gcd
-        self.denominator = denominator // gcd
+        gcd = self.gcd(numerator, denominator)
+        self._numerator = numerator // gcd
+        self._denominator = denominator // gcd
+
+
     def gcd(a, b):
-        #TODO
-        pass
+        # calculated using the euclidean algorithm 
+        if b == 0:
+            return abs(a)
+        else:
+            Fraction.gcd(b, a % b)
+
 
     def get_numerator(self):
         #TODO
@@ -40,8 +46,3 @@ class Fraction(object):
     def get_fraction(self):
         #TODO
         pass
-
-class ZeroDivisionError(Exception):
-    def __init__(self, message="Denominator cannot be zero"):
-        self.message = message
-        super.__init__(self.message)


### PR DESCRIPTION
Creating a ZeroDivisionError was required by the specifications to handle cases where the denominator is zero